### PR TITLE
swap mockserver with okhttp

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
         implementation 'androidx.webkit:webkit:1.4.0'
         implementation 'androidx.browser:browser:1.3.0'
         implementation 'androidx.appcompat:appcompat:1.2.0'
-        implementation 'com.squareup.okhttp3:mockwebserver:3.14.7'
+        testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.7'
         implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
         implementation 'androidx.webkit:webkit:1.4.0'
         implementation 'androidx.browser:browser:1.3.0'
         implementation 'androidx.appcompat:appcompat:1.2.0'
-        testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.7'
+        implementation 'com.squareup.okhttp3:okhttp:3.14.9'
         implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     }
 }


### PR DESCRIPTION
The original upstream project uses `mockserver` pinned at a specific version which is problematic for anyone using (in our case) `4.4.0`.  This change resolved that for a project I deal with.

Looking at this project; the packages used are all okhttp client oriented; so swapping it from `mockserver` to `okhttp` seems like the best thing to do to avoid conflicts with test frameworks.